### PR TITLE
Obtain Svartlebee's Woundseeker in Waukeen's Rest

### DIFF
--- a/checklist.md
+++ b/checklist.md
@@ -84,7 +84,8 @@
 # Waukeen's Rest
 - ::missable::Save two people ([1](https://bg3.wiki/wiki/Rescue_the_Trapped_Man)) ([2](https://bg3.wiki/wiki/Rescue_the_Grand_Duke)) from the [burning inn](https://bg3.wiki/wiki/Waukeen%27s_Rest) (after encountering the area, if you fast travel or rest, they will both die)
   - Help one of them [find a certain ring](https://bg3.wiki/wiki/Dowry_Ring)
-  - Don't rest before saving them once you see them, or this quest will be lost! 
+  - Don't rest before saving them once you see them, or this quest will be lost!
+- After breaking down a door, obtain a [unique sword](https://bg3.wiki/wiki/Svartlebee%27s_Woundseeker) by [commanding](https://bg3.wiki/wiki/Command) its [wielder](https://bg3.wiki/wiki/Yeva) to drop it.
 - Free [the shipment holders](https://bg3.wiki/wiki/Find_the_Missing_Shipment) from the gnoll attackers
   - Keep at least one alive to learn the password
   - Grab [the shipment item](https://bg3.wiki/wiki/Iron_Flask) from the chest they give you 


### PR DESCRIPTION
Credit to [GMWorkshop](https://www.youtube.com/shorts/6yidMh_gpuM) and the [wiki](https://bg3.wiki/wiki/Svartlebee%27s_Woundseeker).