### PR TITLE
Item and Icons contribution

### DIFF
--- a/checklist.md
+++ b/checklist.md
@@ -8,6 +8,13 @@
 - ::item::This represents missable or limited items.
 - ::ability::This represents missable or limited skills, spells or abilities.
 - ::missable::This represents time sensitive mechanics that can be failed.
+- ::item_ordinary::
+- ::item_common::
+- ::item_uncommon::
+- ::item_rare::
+- ::item_veryrare::
+- ::item_legendary::
+- ::item_story::
 # Act 1 Main Missables Entry List
 - Turn in a quest to [save the tieflings](https://bg3.wiki/wiki/Save_the_Refugees) in the grove -- you'll get a pair of gloves 
 - ::missable::Buy any [goblin vendor](https://bg3.wiki/wiki/Grat_the_Trader) items before angering the goblin camp
@@ -17,8 +24,8 @@
 - If you reach a [burning building](https://bg3.wiki/wiki/Waukeen's_Rest), do not long rest
 - Complete other quests before [killing 3 goblin camp leaders](https://bg3.wiki/wiki/Defeat_the_Goblins)
 # Nautiloid
-- ::ability::[URL](https://bg3.wiki/wiki/Us) Make a friend that can grant a missable ability later.
-- ::item:: [URL1](https://bg3.wiki/wiki/Dark_Mind) [URL2](https://bg3.wiki/wiki/Slave_Mind) Pick up some missable items for some dialogue later.
+- ::ability:: Make a [friend](https://bg3.wiki/wiki/Us) that can grant a missable ability later.
+- ::item:: Pick up some missable items [1](https://bg3.wiki/wiki/Dark_Mind) [2](https://bg3.wiki/wiki/Slave_Mind)  for some dialogue later.
 - ::item:: [URL](https://bg3.wiki/wiki/Lae%27zel) Recruit a companion for some missable items.
 - ::item:: [URL](https://bg3.wiki/wiki/Shadowheart) Recruit a second companion for some missable items.
 - ::item:: [URL](https://bg3.wiki/wiki/Bandit%27s%20Armour) Unequip a companion for a missable item later.

--- a/checklist.md
+++ b/checklist.md
@@ -1,4 +1,3 @@
-
 # Getting Started (Feel Free to Check These Off)
 - As a rule of thumb, if you see "tie up any loose ends" while visiting a door to a new area, you may not be able to return -- don't go unless you're done!
 - This guide assumes you're completing everything on your quest log -- this list contains mostly tasks you may miss without seeing a related Journal entry
@@ -24,29 +23,24 @@
 - If you reach a [burning building](https://bg3.wiki/wiki/Waukeen's_Rest), do not long rest
 - Complete other quests before [killing 3 goblin camp leaders](https://bg3.wiki/wiki/Defeat_the_Goblins)
 # Nautiloid
-- ::task:: General tasks:
-  - ::task:: No general tasks.
-- ::missable:: Time sensitive tasks that can be failed:
-  - ::missable:: [Escape the Nautiloid before time runs out.](https://bg3.wiki/wiki/Prologue) 
-- ::item_story::Missable or limited story items:
-    - ::item_story:: No story items.
-- ::ability:: Missable or limited skills, spells or abilities:
-  - ::ability:: Make a [friend](https://bg3.wiki/wiki/Us) and keep him alive to be granted a missable ability later.
-- ::item_common:: Missable or limited items:
-  - ::item_uncommon:: Kill or Command (Drop) an [enemy](https://bg3.wiki/wiki/Zhalk) for a missable [item](https://bg3.wiki/wiki/Everburn_Blade).
-- ::item_ordinary:: Ordinary items may be unique in name, but don't differ from regular items. Missable or limited ordinary items:
-  - ::item_ordinary:: Pick up some missable items [1](https://bg3.wiki/wiki/Dark_Mind) [2](https://bg3.wiki/wiki/Slave_Mind)  for some dialogue later.
-  - ::item_ordinary:: Recruit a [companion](https://bg3.wiki/wiki/Lae%27zel) for some missable items [1](https://bg3.wiki/wiki/Githyanki_Boots) [2](https://bg3.wiki/wiki/Lae%27zel%27s_Clothes) [3](https://bg3.wiki/wiki/Lae%27zel%27s_Underwear) [4](https://bg3.wiki/wiki/Tasteful_Boots).
-  - ::item_ordinary:: Recruit a second [companion](https://bg3.wiki/wiki/Shadowheart) for some missable items [1](https://bg3.wiki/wiki/Circlet) [2](https://bg3.wiki/wiki/Chain_Shirt) [3](https://bg3.wiki/wiki/Shadowheart%27s_Clothes) [4](https://bg3.wiki/wiki/Shadowheart%27s_Underwear) [5](https://bg3.wiki/wiki/Tasteful_Boots).
-  - ::item_ordinary:: Unequip a companion for a missable [item](https://bg3.wiki/wiki/Bandit%27s%20Armour) later.
+- ::missable:: [Escape the Nautiloid before time runs out.](https://bg3.wiki/wiki/Prologue) 
+- ::ability:: Make a [friend](https://bg3.wiki/wiki/Us) and keep him alive to be granted a missable ability later.
+- ::item_uncommon:: Kill or Command (Drop) an [enemy](https://bg3.wiki/wiki/Zhalk) for a missable [item](https://bg3.wiki/wiki/Everburn_Blade).
+- ::item_ordinary:: Pick up some missable items [1](https://bg3.wiki/wiki/Dark_Mind) [2](https://bg3.wiki/wiki/Slave_Mind)  for some dialogue later.
+- ::item_ordinary:: Recruit a [companion](https://bg3.wiki/wiki/Lae%27zel) for some missable items [1](https://bg3.wiki/wiki/Githyanki_Boots) [2](https://bg3.wiki/wiki/Lae%27zel%27s_Clothes) [3](https://bg3.wiki/wiki/Lae%27zel%27s_Underwear) [4](https://bg3.wiki/wiki/Tasteful_Boots).
+- ::item_ordinary:: Recruit a second [companion](https://bg3.wiki/wiki/Shadowheart) for some missable items [1](https://bg3.wiki/wiki/Circlet) [2](https://bg3.wiki/wiki/Chain_Shirt) [3](https://bg3.wiki/wiki/Shadowheart%27s_Clothes) [4](https://bg3.wiki/wiki/Shadowheart%27s_Underwear) [5](https://bg3.wiki/wiki/Tasteful_Boots).
+- ::item_ordinary:: Unequip a companion for a missable [item](https://bg3.wiki/wiki/Bandit%27s%20Armour) later.
 # Ravaged Beach
 - Take revenge on your tentacled captor from the intro
-# Wilderness
-- [Help Lae'zel](https://bg3.wiki/wiki/Lae%27zel#Recruitment) drop out of her wooden bars
+- Check out [Astarion](https://bg3.wiki/wiki/Astarion)'s boar and add him to your party
+# Roadside Cliffs
 - Give [Gale](https://bg3.wiki/wiki/Gale) a hand (don't take a hand) in a teleporter and add him to your party
   - ::missable::Feed him, once he brings up his hunger, within 2 long rests or face some serious consequences
-- Check out [Astarion](https://bg3.wiki/wiki/Astarion)'s boar and add him to your party
+- [Help Lae'zel](https://bg3.wiki/wiki/Lae%27zel#Recruitment) drop out of her wooden bars
+# Roadside Cliffs (Harper's Outpost)
 - Optionally (very optionally) get [five temporary spider friends](https://bg3.wiki/wiki/Spider_Egg_Sac)
+# Overgrown Ruins
+# Refectory
 # Dank Crypt
 - Gain access to [a character that re-specs you](https://bg3.wiki/wiki/Withers)
 - Check out the [secret book](https://bg3.wiki/wiki/Book_of_Dead_Gods) that reveals information about gods
@@ -72,6 +66,18 @@
 - After [recruiting a new bear friend](https://bg3.wiki/wiki/Rescue_the_Druid_Halsin), speak to Rath and enter the [Druid vault](https://bg3.wiki/wiki/Hidden_Vault)
 - Optionally [steal the Idol for Mol](https://bg3.wiki/wiki/Steal_the_Sacred_Idol) (BEFORE finishing Goblin Camp, and after exposing Kagha)
 - After rescuing the Tieflings, get the Hellrider's Pride from [Zevlor](https://bg3.wiki/wiki/Zevlor)
+# Druid's Chambers
+# Enclave Library
+# Hidden Vault
+# Inner Sanctum
+# Sacred Pool
+# Secluded Chamber
+# Secluded Cove
+# Servants' Quarters
+# The Hollow
+# Tiefling Hideout
+# Forest
+# Underground Passage
 # Goblin Camp
 - [Chase the chicken](https://bg3.wiki/wiki/Owlbear_Cub) (do the Owlbear Cave first)
 - Rescue [Volo](https://bg3.wiki/wiki/Volo)
@@ -79,11 +85,15 @@
   - Let him hit you three times to get [a permanent buff](https://bg3.wiki/wiki/Loviatar%27s_Love_(Condition) (at least until the character that gets the buff dies)
 - Rescue [Halsin](https://bg3.wiki/wiki/Halsin) 
 - Eliminate the [three True Soul goblin leaders](https://bg3.wiki/wiki/Defeat_the_Goblins)
+# Shattered Sanctum
+# Worg Pens
+# Defiled Temple
 # The Risen Road
 - Meet [Karlach](https://bg3.wiki/wiki/Karlach)
 - ::missable::[Deal with the paladins](https://bg3.wiki/wiki/Hunt_the_Devil) she brings up before going to Act 1.5, or deal with some permanent consequences
 - Find the [Silver Pendant](https://bg3.wiki/wiki/Silver_Pendant) 
 - ::missable::Protect [two](https://bg3.wiki/wiki/Rugan) [people](https://bg3.wiki/wiki/Olly) being attacked by furries to start the [missing shipment](https://bg3.wiki/wiki/Find_the_Missing_Shipment) quest (if you encounter them and long rest without saving them, they'll permanently die)
+# The Risen Road (Toll House)
 # Blighted Village
 - ::missable::Find two new friends [next to a dead man](https://bg3.wiki/wiki/Edowin) (if you don't interact in time they'll leave)
   - Consume what lies in the dwarf's noggin
@@ -99,10 +109,12 @@
 - Kill the [ogres](https://bg3.wiki/wiki/Lump_the_Enlightened)
   - Nab the [Headband of Intellect](https://bg3.wiki/wiki/Warped_Headband_of_Intellect)
 - In one of the houses north of the village, there is a bugbear having a moment with their partner
-# Githyanki Patrol
+# Apothecary's Cellar
+# Whispering Depths
+# Mountain Pass
 - After you discover [Kith'rak Voss](https://bg3.wiki/wiki/Kith%27rak_Voss), speak to him before long resting, or deal with some permanent consequences
 - If you decide to fight, remember you can cause [Kith'rak Voss](https://bg3.wiki/wiki/Kith%27rak_Voss) to drop his sword for Lae'zel with the command spell
-# Owlbear Cave
+# Owlbear Nest
 - ::missable::[Fight some owlbears](https://bg3.wiki/wiki/Owlbear_Nest) and leave a scent to follow for the baby (do this now, or an owlbear will die after a long rest)
 - Check out [the shrine](https://bg3.wiki/wiki/Owlbear_Nest#Sel%C3%BBne_Shrine) and complete a shrine puzzle to unlock a chest
 # Waukeen's Rest
@@ -112,16 +124,20 @@
 - After breaking down a door, obtain a [unique sword](https://bg3.wiki/wiki/Svartlebee%27s_Woundseeker) by [commanding](https://bg3.wiki/wiki/Command) its [wielder](https://bg3.wiki/wiki/Yeva) to drop it.
 - Free [the shipment holders](https://bg3.wiki/wiki/Find_the_Missing_Shipment) from the gnoll attackers
   - Keep at least one alive to learn the password
-  - Grab [the shipment item](https://bg3.wiki/wiki/Iron_Flask) from the chest they give you 
-# Thief Hideout
+  - Grab [the shipment item](https://bg3.wiki/wiki/Iron_Flask) from the chest they give you
+# Zhentarim Hideout
 - One of the cows next to the entrace to the [Thief Hideout](https://bg3.wiki/wiki/Zhentarim_Basement) has interesting dialogue if you've got Speak with Animals
 - Enter the basement to the [Thief Hideout](https://bg3.wiki/wiki/Zhentarim_Basement)
 - Free [the artist](https://bg3.wiki/wiki/Free_the_Artist)
 - Optionally buy the [gloves of thievery](https://bg3.wiki/wiki/Gloves_of_Thievery) before dealing with the thieves
-# Putrid Bog & Riverside Teahouse
+# Sunlit Wetlands
 - Explore [the place where Kagha met the shadow druids](https://bg3.wiki/wiki/Investigate_Kagha) and defeat the attackers (investigate the giant stump or you can't complete the relevant quest)
-- Save a [pregnant mother](https://bg3.wiki/wiki/Save_Mayrina)
 - Meet a [monster hunter](https://bg3.wiki/wiki/Gandrel) and deal with him as you see fit
+# Riverside Teahouse
+- Save a [pregnant mother](https://bg3.wiki/wiki/Save_Mayrina)
+# Overgrown Tunnel
+# Overgrown Tunnel (Ancient Abode)
+# Overgrown Tunnel (Acrid Workshop)
 # Underdark
 - Clear out the [outpost area that offers protection from monsters](https://bg3.wiki/wiki/Sel%C3%BBnite_Outpost)
   - Light the sconces and braziers in the area to solve the wall puzzles 
@@ -142,7 +158,13 @@
 - Defeat the drow that handles hooked horror monsters
 - Fight [a land shark](https://baldursgate3.wiki.fextralife.com/Bulette)
 - If you find a small grave site in a clearing, don't touch it until you read a certain note regarding a canine companion in the Arcane Tower
-  - Once you've done that, grab the collar from within and use it with the Arcane Tower button 
+  - Once you've done that, grab the collar from within and use it with the Arcane Tower button
+# Bibberbang Grotto
+# Decrepit Village
+# Dread Hollow
+# Myconid Colony
+# Selûnite Outpost
+# The Festering Cove
 # Arcane Tower
 - Use the dog collar to [achieve an unexpected result with a button](https://bg3.wiki/wiki/Dog_Collar)
   - Find and dig on a dog's grave on the Underdark Road to find the necessary item
@@ -151,7 +173,7 @@
 - Don't forget to read all notes and be a good soul 
 - There is a gith disk, don't forget to interact with it after picking it up, and show it to Lae'zel 
 - Use the [Stool of Mysterious Strength](https://bg3.wiki/wiki/Club_of_Hill_Giant_Strength) to get a one-of-a-kind item
-# Grymforge area
+# Grymforge
 - Get [the sergeant's boots](https://bg3.wiki/wiki/Find_the_Missing_Boots)
 - Talk to a [gnome with runepowder](https://bg3.wiki/wiki/Philomeen), past hidden kitchen area of Grymforge
 - ::missable::Free a certain [Drow](https://bg3.wiki/wiki/Free_True_Soul_Nere) (if you long rest or fast travel he'll die)
@@ -164,17 +186,20 @@
 - Loot the [mimics](https://bg3.wiki/wiki/Mimic)
 - Kill some [piggies](https://bg3.wiki/wiki/Hellsboar) in [the area](https://bg3.wiki/wiki/Grymforge#Abandoned_Temple) and optionally get [some masks](https://bg3.wiki/wiki/Devilfoil_Mask)
 - Don't take the elevator up until you've done the creche and other Act 1.5 content
+# Abandoned Refuge
+# Abandoned Refuge (Ancient Forge)
+# The Adamantine Forge
 # BEFORE CONTINUING TO ACT 1.5
 - Clear anything remaining in your quest log for the area (some items will be unresolved, but do whatever's on your map) before going to Act 1.5
-# Act 1.5 Road
+# Rosymorn Monastery Trail
 - Undead attackers on the road
   - Use speak with dead on corpses surrounding them
 - Talk to a [blue Jay friend](https://bg3.wiki/wiki/Reclaim_the_Blue_Jay%27s_Nest) and eagles' nest
 - Speak with [an ancient mage](https://bg3.wiki/wiki/Elminster#Act_Two) at entrance to the Shadow-Cursed Lands
 - Don't continue to Moonrise Towers until you've completed the Grymforge (Underdark) content
-# Monastary
+# Rosymorn Monastery
 - Solve a puzzle that involves the [blood of a god](https://bg3.wiki/wiki/Find_the_Blood_of_Lathander)  
-# Creche
+# Crèche Y'llek
 - Save the student in the Classroom and get [the second githyanki disc](https://bg3.wiki/wiki/Discover_the_history_of_Prince_Orpheus#Moonrise_Towers) from him, then talk to Lae'zel
 - Gith Egg quest
 - Visit the infirmary and get ready to try [the machine](https://bg3.wiki/wiki/Zaith%27isk)
@@ -183,6 +208,10 @@
 - Have a conversation with [the inquisitor](https://bg3.wiki/wiki/W%27wargaz)
 - Perform an [Astral Plane](https://bg3.wiki/wiki/Astral_Plane) visit, and then talk to Lae'zel
   - Talk to [the visitor](https://bg3.wiki/wiki/Voss) upon a long rest
+# Crèche Y'llek (Classroom)
+# Crèche Y'llek (Hatchery)
+# Crèche Y'llek (Infirmary)
+# Crèche Y'llek (Inquisitor's Chamber)
 # BEFORE CONTINUING TO ACT 2
 - Let a certain Dandy [shove an icepick in your eye](https://bg3.wiki/wiki/Volo%27s_Ersatz_Eye) for a permanent upgrade (unconfirmed that this has to be before Act 2)
 - Deluxe edition -- portraits: optionally find Fane in The Ruins, Lohse near Nettie in The Emerald Grove, Red Prince in the Waukeen's Rest, Ifan in the Blighted Village, Sebille in the Hag's house, and finally Beast in The Arcane Tower 
@@ -192,8 +221,9 @@
 # Act 2: First Things First
 - Remember if you didn't talk to [Dammon](https://bg3.wiki/wiki/Dammon) in Act 1, do this as soon as you can for [Karlach](https://bg3.wiki/wiki/Karlach)'s poor sake
 - Plan to rescue the prisoners BEFORE Shar's Temple (and the Nightsong questline)
-# The Road
+# House in Deep Shadows
 - Play hide and seek with [a child](https://bg3.wiki/wiki/Oliver), get [a cool ring](https://bg3.wiki/wiki/Ring_of_Shadows)
+# Ruined Battlefield
 - Talk to a man who wants to [make things "right" by interrogating a dead barkeeper](https://bg3.wiki/wiki/Punish_the_Wicked)
 - Save some harpers, find out about the Inn
 - Give a certain companion [a certain flower](https://bg3.wiki/wiki/Night_Orchid) they might have mentioned
@@ -228,24 +258,27 @@
 - [Save the gnomes](https://bg3.wiki/wiki/Rescue_Wulbren) (talk to them before freeing them)
 - [Save the tieflings](https://bg3.wiki/wiki/Rescue_the_Tieflings) 
   - Talk to [the aspiring Tiefling wizard](https://bg3.wiki/wiki/Rolan)
-# Below Moonrise Towers
+# Moonrise Towers (Ketheric's Room)
+# Oubliette
 - Enter [the area under the prisons](https://bg3.wiki/wiki/Oubliette)
 - Get the parasite from a Zealot corpse in the main area you drop into
 - Kill [the monstrosities within](https://bg3.wiki/wiki/Hook_Horror) and complete the area (you can't continue forward for now)
-# Destroyed Town
+# Reithwin Town
 - Find [a young tiefling](https://bg3.wiki/wiki/Arabella#Act_Two) that needs help 
 - Interact with the center statue puzzle to [open a pathway down](https://bg3.wiki/wiki/Sharran_Sanctuary)
   - Complete the puzzle in the room for three temporary buffs ([1](https://bg3.wiki/wiki/Dark_Lady%27s_Grace_(Condition)), ([2](https://bg3.wiki/wiki/Dark_Lady%27s_Awareness_(Condition)), ([3](https://bg3.wiki/wiki/Dark_Lady%27s_Erudition_(Condition)) but DO NOT head further down and complete the area, freeing an important prisoner, or you'll lock yourself out of freeing prisoners at Moonrise
+  - Deal with the gith patrol and [their leader](https://bg3.wiki/wiki/Tska%27an)
 # Mason's Guild
 - Explore [the basement](https://bg3.wiki/wiki/Mason%27s_Guild)
   - Use a [Tower-Shaped Key](https://bg3.wiki/wiki/Tower-Shaped_Key)
 - Investigate [a particular resistance group](https://bg3.wiki/wiki/Investigate_the_Sel%C3%BBnite_Resistance)
 - Check [the cave](https://bg3.wiki/wiki/Mason's_Guild#Mason's_Guild_Basement) under the masonary
+# Reithwin Graveyard
 # House of Healing
 - Find [the lost tiefling child's parents](https://bg3.wiki/wiki/Find_Arabella%27s_Parents)
 - Kill [a surgeon with questionable ethics](https://bg3.wiki/wiki/Malus_Thorm) and take his instrument 
   - Keep him from stabbing you for an achievement
-# Morgue
+# House of Healing Morgue
 - Check out [the morgue](https://bg3.wiki/wiki/House_of_Healing_Morgue) for some lore and good items
 # The Waning Moon
 - Have a [drinking contest](https://bg3.wiki/wiki/Thisobald_Thorm#Find_Ketheric_Thorm's_Relic)
@@ -255,11 +288,10 @@
 # Reithwin Tollhouse
 - Deal with [the "coin boss"](https://bg3.wiki/wiki/Gerringothe_Thorm) 
   - Keep her from doing anything to you for [an achievement](https://bg3.wiki/wiki/Achievements)
-# The Army Encampment 
-- Deal with the gith patrol and [their leader](https://bg3.wiki/wiki/Tska%27an)
 # BEFORE CONTINUING TO THE TEMPLE
 - Clear anything remaining in your quest log for the area (some items will be unresolved, but do whatever's on your map) before entering the Temple
-# Temple of Shar (Do This After Freeing Prisoners from a Certain Dungeon)
+# Grand Mausoleum
+# Gauntlet of Shar
 - Check out the path to the right of the entryway statue for treasure "hidden in darkness"
 - Kill [Balthazar](https://bg3.wiki/wiki/Balthazar)
   - If somehow you don't have a moonlantern yet, pass checks before killing him to get one
@@ -271,14 +303,16 @@
   - [Soft-Step Trial](https://bg3.wiki/wiki/Gauntlet_of_Shar#Soft-Step_Trial)
   - [Self-Same Trial](https://bg3.wiki/wiki/Gauntlet_of_Shar#Self-Same_Trial)
   - [Faith-Leap Trial](https://bg3.wiki/wiki/Gauntlet_of_Shar#Faith-Step_Trial)
-# Approach the Towers
+# Silent Library
+# Shadowfell
+# Moonrise Towers (Revisited)
 - Visit [the Inn](https://bg3.wiki/wiki/Last_Light_Inn) and gather forces
   - Talk to [the Selunite](https://bg3.wiki/wiki/Isobel)
 - Attack [the Towers](https://bg3.wiki/wiki/Infiltrate_Moonrise_Towers#Assaulting_Moonrise_Towers)
   - Pick up two tadpoles in the entryway
 - Join a new fight in the basement cells (even if you cleared it before)
 - Make your way upstairs and [fight the boss](https://bg3.wiki/wiki/Defeat_Ketheric_Thorm)
-# Enter the Enemy Base
+# Mind Flayer Colony
 - Jump into [one of the towers](https://bg3.wiki/wiki/Mind_Flayer_Colony) to enter an enemy base
 - Destroy the undead creatures in [a ritual room](https://bg3.wiki/wiki/Mind_Flayer_Colony#Necrotic_laboratory)
   - Complete the brain puzzle
@@ -302,4 +336,86 @@
   - ::missable::[Save a tentacled friend](https://bg3.wiki/wiki/Retrieve_Omeluum)
 - ::missable::[Stop the bad news](https://bg3.wiki/wiki/Stop_the_Presses) from spreading before making a long rest
 - When meeting a Djinni at a circus, trick your way into winning the jackpot!
-  - ::missable:: When he teleports you to another area, loot everything since you can't go back to [that place](https://bg3.wiki/wiki/Jungle) 
+  - ::missable:: When he teleports you to another area, loot everything since you can't go back to [that place](https://bg3.wiki/wiki/Jungle)
+# Abandoned Windmill
+# Ancient Lair
+# Angleiron's Cellar
+# Arfur's Mansion
+# Arfur's Mansion (Basement)
+# Astral Plane
+# Baldur's Mouth
+# Baldur's Mouth (Basement)
+# Basilisk Gate Barracks
+# Bloomridge Park
+# Bonecloak's Apothecary
+# Campsite
+# Carm's Garm
+# Cazador's Dungeon
+# Chromatic Scale
+# Circus of the Last Days
+# Cloister of Sombre Embrace
+# Crimson Draughts
+# Danthelon's Dancing Axe
+# Devil's Den
+# Devil's Fee
+# Elerrathin's Home
+# Elerrathin's Home (Jaheira's Basement)
+# Elfsong Tavern
+# Elfsong Tavern (Basement)
+# Elminster's Library
+# Facemaker's Boutique
+# Felogyr's Fireworks
+# Flymm Cargo
+# Flymm's Cobblers
+# Forge of the Nine
+# Fraygo's Flophouse
+# Guildhall
+# Gur Camp
+# Heapside Prison
+# Hhune Mausoleum
+# Highberry's Home
+# House of Grief
+# House of Hope
+# Iron Throne
+# Jungle
+# Knights of the Shield Hideout
+# Lady Jannath's Estate
+# Lower City
+# Lower City Sewers
+# Morphic Pool
+# Murder Tribunal
+# Nortale's Hostel
+# Old Garlow's Place
+# Open Hand Temple
+# Philgrave's Mansion
+# Ramazith's Tower
+# Requisitioned Barn
+# Rivington
+# Rivington (Western Beach)
+# Sharess' Caress
+# Sharran Enclave
+# Sorcerous Sundries
+# Steel Watch Foundry
+# Stormshore Armoury
+# Stormshore Tabernacle
+# Sword Coast Couriers
+# Szarr Palace
+# Temple of Bhaal
+# The Bibliophile
+# The Blushing Mermaid
+# The Counting House
+# The Dragon's Sanctum
+# The Glitter Gala
+# The High Hall
+# The Lodge
+# The Lodge - Basement Docks
+# The Wyrmway
+# Under Temple Cave Area
+# Undercity Ruins
+# Vonayn's Home
+# Water Queen's House
+# Windmill Basement
+# Wine Festival
+# Wyrm's Crossing
+# Wyrm's Crossing (The Velveteen Elixir)
+# Wyrm's Rock Fortress

--- a/checklist.md
+++ b/checklist.md
@@ -26,9 +26,9 @@
 # Nautiloid
 - ::ability:: Make a [friend](https://bg3.wiki/wiki/Us) and keep him alive to be granted a missable ability later.
 - ::item_common:: Pick up some missable items [1](https://bg3.wiki/wiki/Dark_Mind) [2](https://bg3.wiki/wiki/Slave_Mind)  for some dialogue later.
-- ::item_common:: Recruit a [companion](https://bg3.wiki/wiki/Lae%27zel) for some missable items.
-- ::item_common:: Recruit a second [companion](https://bg3.wiki/wiki/Shadowheart) for some missable items.
-- ::item_common:: Unequip a companion for a missable [item](https://bg3.wiki/wiki/Bandit%27s%20Armour) later.
+- ::item_ordinary:: Recruit a [companion](https://bg3.wiki/wiki/Lae%27zel) for some missable items.
+- ::item_ordinary:: Recruit a second [companion](https://bg3.wiki/wiki/Shadowheart) for some missable items.
+- ::item_ordinary:: Unequip a companion for a missable [item](https://bg3.wiki/wiki/Bandit%27s%20Armour) later.
 - ::item_uncommon:: Kill or Command (Drop) an [enemy](https://bg3.wiki/wiki/Zhalk) for a missable [item](https://bg3.wiki/wiki/Everburn_Blade).
 # Ravaged Beach
 - Take revenge on your tentacled captor from the intro

--- a/checklist.md
+++ b/checklist.md
@@ -4,17 +4,17 @@
 - This guide assumes you're completing everything on your quest log -- this list contains mostly tasks you may miss without seeing a related Journal entry
 - Always crouch when stealing -- enemies will automatically  start investigating if not
 - Send all camp supplies to camp -- they'll automatically show up when you Long Rest
-- ::task::This represents general tasks.
-- ::item::This represents missable or limited items.
-- ::ability::This represents missable or limited skills, spells or abilities.
-- ::missable::This represents time sensitive mechanics that can be failed.
-- ::item_ordinary::
-- ::item_common::
-- ::item_uncommon::
-- ::item_rare::
-- ::item_veryrare::
-- ::item_legendary::
-- ::item_story::
+- The following icon usage is described below
+  - ::task::This represents general tasks.
+  - ::missable::This represents time sensitive tasks that can be failed.
+  - ::ability::This represents missable or limited skills, spells or abilities.
+  - ::item_common::This represents missable or limited common items.
+  - ::item_uncommon::This represents missable or limited uncommon items.
+  - ::item_rare::This represents missable or limited rare items.
+  - ::item_veryrare::This represents missable or limited very rare items.
+  - ::item_legendary::This represents missable or limited legendary items.
+  - ::item_story::This represents missable or limited story items.
+  - ::item_ordinary::This represents missable or limited ordinary items.  Ordinary items may be unique in name, but don't differ from regular items.
 # Act 1 Main Missables Entry List
 - Turn in a quest to [save the tieflings](https://bg3.wiki/wiki/Save_the_Refugees) in the grove -- you'll get a pair of gloves 
 - ::missable::Buy any [goblin vendor](https://bg3.wiki/wiki/Grat_the_Trader) items before angering the goblin camp

--- a/checklist.md
+++ b/checklist.md
@@ -4,6 +4,7 @@
 - This guide assumes you're completing everything on your quest log -- this list contains mostly tasks you may miss without seeing a related Journal entry
 - Always crouch when stealing -- enemies will automatically  start investigating if not
 - Send all camp supplies to camp -- they'll automatically show up when you Long Rest
+- ::task::This represents general tasks. ::item::This represents missable or limited items. ::ability::This represents missable or limited skills, spells or abilities. ::missable::This represents time sensitive mechanics that can be failed.
 # Act 1 Main Missables Entry List
 - Turn in a quest to [save the tieflings](https://bg3.wiki/wiki/Save_the_Refugees) in the grove -- you'll get a pair of gloves 
 - ::missable::Buy any [goblin vendor](https://bg3.wiki/wiki/Grat_the_Trader) items before angering the goblin camp
@@ -13,11 +14,12 @@
 - If you reach a [burning building](https://bg3.wiki/wiki/Waukeen's_Rest), do not long rest
 - Complete other quests before [killing 3 goblin camp leaders](https://bg3.wiki/wiki/Defeat_the_Goblins)
 # Nautiloid
-- ::gem::test
-- ::missable::test
-- Kill [the devil](https://bg3.wiki/wiki/Commander_Zhalk) to get the [fiery sword](https://bg3.wiki/wiki/Everburn_Blade) (it's useful at least partway through Act 1)
-- Make a decision about the exposed brain -- sparing it may be relevant later in Act 2
-- Grab some green jars ([1](https://bg3.wiki/wiki/Dark_Mind), [2](https://bg3.wiki/wiki/Slave_Mind)) and hold them until the end of Act 2 for interesting dialogue later, although nothing is lost if you don't get them
+- ::ability::[URL](https://bg3.wiki/wiki/Us) Make a friend that can grant a missable ability later.
+- ::item:: [URL1](https://bg3.wiki/wiki/Dark_Mind) [URL2](https://bg3.wiki/wiki/Slave_Mind) Pick up some missable items for some dialogue later.
+- ::item:: [URL](https://bg3.wiki/wiki/Lae%27zel) Recruit a companion for some missable items.
+- ::item:: [URL](https://bg3.wiki/wiki/Shadowheart) Recruit a second companion for some missable items.
+- ::item:: [URL](https://bg3.wiki/wiki/Bandit%27s%20Armour) Unequip a companion for a missable item later.
+- ::item:: [URL](https://bg3.wiki/wiki/Everburn_Blade) Kill or Command (Drop) an enemy for a missable item.
 # Ravaged Beach
 - Take revenge on your tentacled captor from the intro
 # Wilderness

--- a/checklist.md
+++ b/checklist.md
@@ -313,4 +313,3 @@
 - ::item_story:: [URL](https://bg3.wiki/wiki/Amulet%20of%20Bhaal)
 # Szarr Palace
 - ::item_story:: [URL](https://bg3.wiki/wiki/Szarr%20Family%20Ring)
-# Wyrm's Rock Fortress

--- a/checklist.md
+++ b/checklist.md
@@ -27,7 +27,7 @@
 - ::task:: General tasks:
   - ::task:: No general tasks.
 - ::missable:: Time sensitive tasks that can be failed:
-  - ::task:: [Escape the Nautiloid before time runs out.](https://bg3.wiki/wiki/Prologue) 
+  - ::missable:: [Escape the Nautiloid before time runs out.](https://bg3.wiki/wiki/Prologue) 
 - ::item_story::This represents missable or limited story items.
     - ::item_story:: No story items.
 - ::ability:: Missable or limited skills, spells or abilities:

--- a/checklist.md
+++ b/checklist.md
@@ -26,12 +26,12 @@
 # Nautiloid
 - ::ability:: Missable or limited skills, spells or abilities:
   - ::ability:: Make a [friend](https://bg3.wiki/wiki/Us) and keep him alive to be granted a missable ability later.
-- ::item_ordinary:: Missable or limited ordinary items.  Ordinary items may be unique in name, but don't differ from regular items.
+- ::item_ordinary:: Ordinary items may be unique in name, but don't differ from regular items. Missable or limited ordinary items:
   - ::item_ordinary:: Pick up some missable items [1](https://bg3.wiki/wiki/Dark_Mind) [2](https://bg3.wiki/wiki/Slave_Mind)  for some dialogue later.
   - ::item_ordinary:: Recruit a [companion](https://bg3.wiki/wiki/Lae%27zel) for some missable items [1](https://bg3.wiki/wiki/Githyanki_Boots) [2](https://bg3.wiki/wiki/Lae%27zel%27s_Clothes) [3](https://bg3.wiki/wiki/Lae%27zel%27s_Underwear) [4](https://bg3.wiki/wiki/Tasteful_Boots).
   - ::item_ordinary:: Recruit a second [companion](https://bg3.wiki/wiki/Shadowheart) for some missable items [1](https://bg3.wiki/wiki/Circlet) [2](https://bg3.wiki/wiki/Chain_Shirt) [3](https://bg3.wiki/wiki/Shadowheart%27s_Clothes) [4](https://bg3.wiki/wiki/Shadowheart%27s_Underwear) [5](https://bg3.wiki/wiki/Tasteful_Boots).
   - ::item_ordinary:: Unequip a companion for a missable [item](https://bg3.wiki/wiki/Bandit%27s%20Armour) later.
-- ::item_common:: Missable or limited items.
+- ::item_common:: Missable or limited items:
   - ::item_uncommon:: Kill or Command (Drop) an [enemy](https://bg3.wiki/wiki/Zhalk) for a missable [item](https://bg3.wiki/wiki/Everburn_Blade).
 # Ravaged Beach
 - Take revenge on your tentacled captor from the intro

--- a/checklist.md
+++ b/checklist.md
@@ -72,10 +72,10 @@
 # Sacred Pool
 # Secluded Chamber
 # Secluded Cove
-- ::item_story:: Perform with [Alfira](https://bg3.wiki/wiki/Alfira) to obtain an [item](https://bg3.wiki/wiki/Lihala%27s%20Lute).
+- ::item_story:: Perform with [Alfira](https://bg3.wiki/wiki/Alfira) to obtain an [Lute](https://bg3.wiki/wiki/Lihala%27s%20Lute).
 # Servants' Quarters
 # The Hollow
-- ::item_story:: Find the [item](https://bg3.wiki/wiki/Brass%20Locket) to complete the [quest](https://bg3.wiki/wiki/Return_the_Locket).
+- ::item_story:: Find the [stolen locket](https://bg3.wiki/wiki/Brass%20Locket) to complete a [quest](https://bg3.wiki/wiki/Return_the_Locket).
 # Tiefling Hideout
 # Forest
 # Underground Passage
@@ -87,7 +87,7 @@
 - Rescue [Halsin](https://bg3.wiki/wiki/Halsin) 
 - Eliminate the [three True Soul goblin leaders](https://bg3.wiki/wiki/Defeat_the_Goblins)
 # Shattered Sanctum
-- ::story_item:: The first opportunity to obtain a [limited item](https://bg3.wiki/wiki/Spider%27s%20Lyre).
+- ::story_item:: The first opportunity to obtain a [Spider Lyre](https://bg3.wiki/wiki/Spider%27s%20Lyre).
 # Worg Pens
 # Defiled Temple
 # The Risen Road
@@ -97,7 +97,7 @@
 - ::missable::Protect [two](https://bg3.wiki/wiki/Rugan) [people](https://bg3.wiki/wiki/Olly) being attacked by furries to start the [missing shipment](https://bg3.wiki/wiki/Find_the_Missing_Shipment) quest (if you encounter them and long rest without saving them, they'll permanently die)
 # The Risen Road (Toll House)
 # Blighted Village
-- ::item_story:: The first opportunity to find a missable [item](https://bg3.wiki/wiki/Bloody%20Amulet).  It is not recommended to obtain this.
+- ::item_story:: The first opportunity to find the [Bloody Amulet](https://bg3.wiki/wiki/Bloody%20Amulet).  It is not recommended to obtain this.
 - ::missable::Find two new friends [next to a dead man](https://bg3.wiki/wiki/Edowin) (if you don't interact in time they'll leave)
   - Consume what lies in the dwarf's noggin
   - Combine the [shaft](https://bg3.wiki/wiki/Shaft_of_a_Broken_Spear) he has on his person with [an item from the nearby cave](https://bg3.wiki/wiki/Head_of_a_Broken_Spear) to create [a powerful item](https://bg3.wiki/wiki/Vision_of_the_Absolute)
@@ -228,7 +228,8 @@
 # House in Deep Shadows
 - Play hide and seek with [a child](https://bg3.wiki/wiki/Oliver), get [a cool ring](https://bg3.wiki/wiki/Ring_of_Shadows)
 # Ruined Battlefield
-- ::missable:: ::item_story:: First opportunity to find a missable [item](https://bg3.wiki/wiki/Moonlantern) from an [enemy](https://bg3.wiki/wiki/Kar%27niss).
+- ::item_story:: First opportunity to find a [Moonlantern](https://bg3.wiki/wiki/Moonlantern), dropped from an [enemy](https://bg3.wiki/wiki/Kar%27niss).
+  - ::missable:: This version of the item is time limited and must be obtained before the target reaches Moonrise Towers (depending on how the player entered Act 2).  It is recommended to obtain this item ASAP.
   - ::item_common:: It is higly recommended to get this one, as it grants another missable [item](https://bg3.wiki/wiki/Filigreed_Feywild_Bell) and affects a future interaction with a little [friend](https://bg3.wiki/wiki/Dolly_Dolly_Dolly)
 - Talk to a man who wants to [make things "right" by interrogating a dead barkeeper](https://bg3.wiki/wiki/Punish_the_Wicked)
 - Save some harpers, find out about the Inn

--- a/checklist.md
+++ b/checklist.md
@@ -26,13 +26,13 @@
 # Nautiloid
 - ::ability:: Missable or limited skills, spells or abilities:
   - ::ability:: Make a [friend](https://bg3.wiki/wiki/Us) and keep him alive to be granted a missable ability later.
+- ::item_common:: Missable or limited items:
+  - ::item_uncommon:: Kill or Command (Drop) an [enemy](https://bg3.wiki/wiki/Zhalk) for a missable [item](https://bg3.wiki/wiki/Everburn_Blade).
 - ::item_ordinary:: Ordinary items may be unique in name, but don't differ from regular items. Missable or limited ordinary items:
   - ::item_ordinary:: Pick up some missable items [1](https://bg3.wiki/wiki/Dark_Mind) [2](https://bg3.wiki/wiki/Slave_Mind)  for some dialogue later.
   - ::item_ordinary:: Recruit a [companion](https://bg3.wiki/wiki/Lae%27zel) for some missable items [1](https://bg3.wiki/wiki/Githyanki_Boots) [2](https://bg3.wiki/wiki/Lae%27zel%27s_Clothes) [3](https://bg3.wiki/wiki/Lae%27zel%27s_Underwear) [4](https://bg3.wiki/wiki/Tasteful_Boots).
   - ::item_ordinary:: Recruit a second [companion](https://bg3.wiki/wiki/Shadowheart) for some missable items [1](https://bg3.wiki/wiki/Circlet) [2](https://bg3.wiki/wiki/Chain_Shirt) [3](https://bg3.wiki/wiki/Shadowheart%27s_Clothes) [4](https://bg3.wiki/wiki/Shadowheart%27s_Underwear) [5](https://bg3.wiki/wiki/Tasteful_Boots).
   - ::item_ordinary:: Unequip a companion for a missable [item](https://bg3.wiki/wiki/Bandit%27s%20Armour) later.
-- ::item_common:: Missable or limited items:
-  - ::item_uncommon:: Kill or Command (Drop) an [enemy](https://bg3.wiki/wiki/Zhalk) for a missable [item](https://bg3.wiki/wiki/Everburn_Blade).
 # Ravaged Beach
 - Take revenge on your tentacled captor from the intro
 # Wilderness

--- a/checklist.md
+++ b/checklist.md
@@ -24,7 +24,7 @@
 - If you reach a [burning building](https://bg3.wiki/wiki/Waukeen's_Rest), do not long rest
 - Complete other quests before [killing 3 goblin camp leaders](https://bg3.wiki/wiki/Defeat_the_Goblins)
 # Nautiloid
-- ::ability:: Make a [friend](https://bg3.wiki/wiki/Us) that can grant a missable ability later.
+- ::ability:: Make a [friend](https://bg3.wiki/wiki/Us) and keep him alive to be granted a missable ability later.
 - ::item_common:: Pick up some missable items [1](https://bg3.wiki/wiki/Dark_Mind) [2](https://bg3.wiki/wiki/Slave_Mind)  for some dialogue later.
 - ::item_common:: Recruit a [companion](https://bg3.wiki/wiki/Lae%27zel) for some missable items.
 - ::item_common:: Recruit a second [companion](https://bg3.wiki/wiki/Shadowheart) for some missable items.

--- a/checklist.md
+++ b/checklist.md
@@ -13,7 +13,7 @@
   - ::item_veryrare::This represents missable or limited very rare items.
   - ::item_legendary::This represents missable or limited legendary items.
   - ::item_story::This represents missable or limited story items.
-  - ::item_ordinary::This represents missable or limited ordinary items.  Ordinary items may be unique in name, but don't differ from regular items.
+  - ::item_ordinary::This represents missable or limited ordinary items.  Ordinary items may be unique in name, but are not different from regular items.
 # Act 1 Main Missables Entry List
 - Turn in a quest to [save the tieflings](https://bg3.wiki/wiki/Save_the_Refugees) in the grove -- you'll get a pair of gloves 
 - ::missable::Buy any [goblin vendor](https://bg3.wiki/wiki/Grat_the_Trader) items before angering the goblin camp
@@ -45,6 +45,7 @@
 - Gain access to [a character that re-specs you](https://bg3.wiki/wiki/Withers)
 - Check out the [secret book](https://bg3.wiki/wiki/Book_of_Dead_Gods) that reveals information about gods
 # Emerald Grove
+- ::task:: Save an [adventurer](https://bg3.wiki/wiki/Barth) to get a missable [quest](https://bg3.wiki/wiki/Return_the_Locket).
 - You meet [Wyll](https://bg3.wiki/wiki/Wyll) here, so make sure to exhaust his dialogue
 - Talk to [Auntie Ethel](https://bg3.wiki/wiki/Auntie_Ethel) and buy any items you need 
 - ::missable::Save a [certain tiefling child](https://bg3.wiki/wiki/Save_Arabella) from a scaly death (if you solve the conflict between the tieflings and goblins, it'll be too late)
@@ -58,8 +59,6 @@
 - [Strange Ox](https://bg3.wiki/wiki/Strange_Ox) (some dialogue if you got Speak With Animals) -- do NOT kill it, or you'll break future quests!
 - ::missable::Save or kill [the captive goblin](https://bg3.wiki/wiki/Sazza) (note if you save them, after one long rest the goblin leaders can no longer be spoken to!)
 - After recusing Halsin, be sure to speak to [Rath](https://bg3.wiki/wiki/Rath) to get access to the druid vault
-- Speak with [Alfira](https://bg3.wiki/wiki/Alfira) within the Grove 
-  - Learn an instrument by playing along
 - You will find [Dammon](https://bg3.wiki/wiki/Dammon) who has something important for [Karlach](https://bg3.wiki/wiki/Karlach)
 - ::missable::Stop an [Assassin](https://bg3.wiki/wiki/Nadira) -- go past the entrance, immediately turn right up the hill (failing to help in this case will cause a permanent NPC death)
 - Heal the [paralyzed Tiefling](https://bg3.wiki/wiki/Pandirna)
@@ -73,8 +72,10 @@
 # Sacred Pool
 # Secluded Chamber
 # Secluded Cove
+- ::item_story:: Perform with [Alfira](https://bg3.wiki/wiki/Alfira) to obtain an [item](https://bg3.wiki/wiki/Lihala%27s%20Lute).
 # Servants' Quarters
 # The Hollow
+- ::item_story:: Find the [item](https://bg3.wiki/wiki/Brass%20Locket) to complete the [quest](https://bg3.wiki/wiki/Return_the_Locket).
 # Tiefling Hideout
 # Forest
 # Underground Passage
@@ -86,6 +87,7 @@
 - Rescue [Halsin](https://bg3.wiki/wiki/Halsin) 
 - Eliminate the [three True Soul goblin leaders](https://bg3.wiki/wiki/Defeat_the_Goblins)
 # Shattered Sanctum
+- ::story_item:: The first opportunity to obtain a [limited item](https://bg3.wiki/wiki/Spider%27s%20Lyre).
 # Worg Pens
 # Defiled Temple
 # The Risen Road
@@ -95,6 +97,7 @@
 - ::missable::Protect [two](https://bg3.wiki/wiki/Rugan) [people](https://bg3.wiki/wiki/Olly) being attacked by furries to start the [missing shipment](https://bg3.wiki/wiki/Find_the_Missing_Shipment) quest (if you encounter them and long rest without saving them, they'll permanently die)
 # The Risen Road (Toll House)
 # Blighted Village
+- ::item_story:: The first opportunity to find a missable [item](https://bg3.wiki/wiki/Bloody%20Amulet).  It is not recommended to obtain this.
 - ::missable::Find two new friends [next to a dead man](https://bg3.wiki/wiki/Edowin) (if you don't interact in time they'll leave)
   - Consume what lies in the dwarf's noggin
   - Combine the [shaft](https://bg3.wiki/wiki/Shaft_of_a_Broken_Spear) he has on his person with [an item from the nearby cave](https://bg3.wiki/wiki/Head_of_a_Broken_Spear) to create [a powerful item](https://bg3.wiki/wiki/Vision_of_the_Absolute)
@@ -135,6 +138,7 @@
 - Meet a [monster hunter](https://bg3.wiki/wiki/Gandrel) and deal with him as you see fit
 # Riverside Teahouse
 - Save a [pregnant mother](https://bg3.wiki/wiki/Save_Mayrina)
+- ::item_story:: A missable [item](https://bg3.wiki/wiki/Mayrina%27s%20Locket) can be obtained here.  Obtaining this item may prevent obtaining other items, so it is not recommended to collect this one. (Alternate methods may be available. Verification needed.)
 # Overgrown Tunnel
 # Overgrown Tunnel (Ancient Abode)
 # Overgrown Tunnel (Acrid Workshop)
@@ -224,16 +228,18 @@
 # House in Deep Shadows
 - Play hide and seek with [a child](https://bg3.wiki/wiki/Oliver), get [a cool ring](https://bg3.wiki/wiki/Ring_of_Shadows)
 # Ruined Battlefield
+- ::missable:: ::item_story:: First opportunity to find a missable [item](https://bg3.wiki/wiki/Moonlantern) from an [enemy](https://bg3.wiki/wiki/Kar%27niss).
+  - ::item_common:: It is higly recommended to get this one, as it grants another missable [item](https://bg3.wiki/wiki/Filigreed_Feywild_Bell) and affects a future interaction with a little [friend](https://bg3.wiki/wiki/Dolly_Dolly_Dolly)
 - Talk to a man who wants to [make things "right" by interrogating a dead barkeeper](https://bg3.wiki/wiki/Punish_the_Wicked)
 - Save some harpers, find out about the Inn
 - Give a certain companion [a certain flower](https://bg3.wiki/wiki/Night_Orchid) they might have mentioned
 - Destroy the everburning torches next to Korliss and fight the shadow mastiffs
 # Last Light Inn
+- ::item_story:: Second chance to get a missable [item](https://bg3.wiki/wiki/Moonlantern).
 - Talk to the inhabitants of [the Inn](https://bg3.wiki/wiki/Last_Light_Inn)
   - Make sure to speak with a pair playing chess ([a tiefling child](https://bg3.wiki/wiki/Mol) and [a familiar opponent](https://bg3.wiki/wiki/Raphael))
   - Talk to [a Strange Ox](https://bg3.wiki/wiki/Strange_Ox) again (don't kill it)
   - Get [a key](https://bg3.wiki/wiki/Tower-Shaped_Key) from a little tiefling thief
-- ::missable::Get [the inhabitant of a lantern](https://bg3.wiki/wiki/Dolly_Dolly_Dolly) to help, thanks to a [drider](https://bg3.wiki/wiki/Kar%27niss) (if you don't talk to the lantern soon enough, you are locked out of being able to speak with her)
 - Save the moon Cleric from the ambush at the Inn and [start hunting for abductees](https://bg3.wiki/wiki/Resolve_the_Abduction)
 - ::missable::[Find the tiefling](https://bg3.wiki/wiki/Find_Rolan_in_the_Shadows) without fast traveling or long resting (only happens after [the battle with the flying enemies](https://bg3.wiki/wiki/Resolve_the_Abduction), and the timer only starts if you walk near him)
   - Save him from some scary shadows
@@ -243,6 +249,7 @@
   - Visit camp to find out more about [the boy](https://bg3.wiki/wiki/Thaniel), post-attack
 - Give [Dammon](https://bg3.wiki/wiki/Dammon) what [he needs](https://bg3.wiki/wiki/Infernal_Iron) to help [Karlach](https://bg3.wiki/wiki/Karlach), two times
 # Moonrise Towers
+- ::item_story:: Final chance to get a missable [item](https://bg3.wiki/wiki/Moonlantern).
 - Get some more tadpoles
   - Convince the guard on the docks to let you investigate the shipping crates
   - Destroy the barrel with the tadpoles after investigating (you can move the crate out of sight of the guards)
@@ -381,9 +388,11 @@
 # Knights of the Shield Hideout
 # Lady Jannath's Estate
 # Lower City
+- ::item_story:: [URL](https://bg3.wiki/wiki/Guild%20Ring)
 # Lower City Sewers
 # Morphic Pool
 # Murder Tribunal
+- ::item_story:: [URL](https://bg3.wiki/wiki/Amulet%20of%20Bhaal)
 # Nortale's Hostel
 # Old Garlow's Place
 # Open Hand Temple
@@ -400,6 +409,7 @@
 # Stormshore Tabernacle
 # Sword Coast Couriers
 # Szarr Palace
+- ::item_story:: [URL](https://bg3.wiki/wiki/Szarr%20Family%20Ring)
 # Temple of Bhaal
 # The Bibliophile
 # The Blushing Mermaid

--- a/checklist.md
+++ b/checklist.md
@@ -308,8 +308,8 @@
 - When meeting a Djinni at a circus, trick your way into winning the jackpot!
   - ::missable:: When he teleports you to another area, loot everything since you can't go back to [that place](https://bg3.wiki/wiki/Jungle)
 # Lower City
-- ::item_story:: [URL](https://bg3.wiki/wiki/Guild%20Ring)
+- ::item_story:: [Story Item Placeholder](https://bg3.wiki/wiki/Guild%20Ring)
 # Murder Tribunal
-- ::item_story:: [URL](https://bg3.wiki/wiki/Amulet%20of%20Bhaal)
+- ::item_story:: [Story Item Placeholder](https://bg3.wiki/wiki/Amulet%20of%20Bhaal)
 # Szarr Palace
-- ::item_story:: [URL](https://bg3.wiki/wiki/Szarr%20Family%20Ring)
+- ::item_story:: [Story Item Placeholder](https://bg3.wiki/wiki/Szarr%20Family%20Ring)

--- a/checklist.md
+++ b/checklist.md
@@ -28,7 +28,7 @@
   - ::task:: No general tasks.
 - ::missable:: Time sensitive tasks that can be failed:
   - ::missable:: [Escape the Nautiloid before time runs out.](https://bg3.wiki/wiki/Prologue) 
-- ::item_story::This represents missable or limited story items.
+- ::item_story::Missable or limited story items:
     - ::item_story:: No story items.
 - ::ability:: Missable or limited skills, spells or abilities:
   - ::ability:: Make a [friend](https://bg3.wiki/wiki/Us) and keep him alive to be granted a missable ability later.

--- a/checklist.md
+++ b/checklist.md
@@ -26,8 +26,8 @@
 # Nautiloid
 - ::ability:: Make a [friend](https://bg3.wiki/wiki/Us) and keep him alive to be granted a missable ability later.
 - ::item_ordinary:: Pick up some missable items [1](https://bg3.wiki/wiki/Dark_Mind) [2](https://bg3.wiki/wiki/Slave_Mind)  for some dialogue later.
-- ::item_ordinary:: Recruit a [companion](https://bg3.wiki/wiki/Lae%27zel) for some missable items.
-- ::item_ordinary:: Recruit a second [companion](https://bg3.wiki/wiki/Shadowheart) for some missable items.
+- ::item_ordinary:: Recruit a [companion](https://bg3.wiki/wiki/Lae%27zel) for some missable items [1](https://bg3.wiki/wiki/Githyanki_Boots) [2](https://bg3.wiki/wiki/Lae%27zel%27s_Clothes) [3](https://bg3.wiki/wiki/Lae%27zel%27s_Underwear) [4](https://bg3.wiki/wiki/Tasteful_Boots).
+- ::item_ordinary:: Recruit a second [companion](https://bg3.wiki/wiki/Shadowheart) for some missable items [1](https://bg3.wiki/wiki/Circlet) [2](https://bg3.wiki/wiki/Chain_Shirt) [3](https://bg3.wiki/wiki/Shadowheart%27s_Clothes) [4](https://bg3.wiki/wiki/Shadowheart%27s_Underwear) [5](https://bg3.wiki/wiki/Tasteful_Boots).
 - ::item_ordinary:: Unequip a companion for a missable [item](https://bg3.wiki/wiki/Bandit%27s%20Armour) later.
 - ::item_uncommon:: Kill or Command (Drop) an [enemy](https://bg3.wiki/wiki/Zhalk) for a missable [item](https://bg3.wiki/wiki/Everburn_Blade).
 # Ravaged Beach

--- a/checklist.md
+++ b/checklist.md
@@ -24,6 +24,12 @@
 - If you reach a [burning building](https://bg3.wiki/wiki/Waukeen's_Rest), do not long rest
 - Complete other quests before [killing 3 goblin camp leaders](https://bg3.wiki/wiki/Defeat_the_Goblins)
 # Nautiloid
+- ::task:: General tasks:
+  - ::task:: No general tasks.
+- ::missable:: Time sensitive tasks that can be failed:
+  - ::task:: [Escape the Nautiloid before time runs out.](https://bg3.wiki/wiki/Prologue) 
+- ::item_story::This represents missable or limited story items.
+    - ::item_story:: No story items.
 - ::ability:: Missable or limited skills, spells or abilities:
   - ::ability:: Make a [friend](https://bg3.wiki/wiki/Us) and keep him alive to be granted a missable ability later.
 - ::item_common:: Missable or limited items:

--- a/checklist.md
+++ b/checklist.md
@@ -13,7 +13,8 @@
 - If you reach a [burning building](https://bg3.wiki/wiki/Waukeen's_Rest), do not long rest
 - Complete other quests before [killing 3 goblin camp leaders](https://bg3.wiki/wiki/Defeat_the_Goblins)
 # Nautiloid
-- ::gem:: test
+- ::gem::test
+- ::missable::test
 - Kill [the devil](https://bg3.wiki/wiki/Commander_Zhalk) to get the [fiery sword](https://bg3.wiki/wiki/Everburn_Blade) (it's useful at least partway through Act 1)
 - Make a decision about the exposed brain -- sparing it may be relevant later in Act 2
 - Grab some green jars ([1](https://bg3.wiki/wiki/Dark_Mind), [2](https://bg3.wiki/wiki/Slave_Mind)) and hold them until the end of Act 2 for interesting dialogue later, although nothing is lost if you don't get them

--- a/checklist.md
+++ b/checklist.md
@@ -25,11 +25,11 @@
 - Complete other quests before [killing 3 goblin camp leaders](https://bg3.wiki/wiki/Defeat_the_Goblins)
 # Nautiloid
 - ::ability:: Make a [friend](https://bg3.wiki/wiki/Us) that can grant a missable ability later.
-- ::item:: Pick up some missable items [1](https://bg3.wiki/wiki/Dark_Mind) [2](https://bg3.wiki/wiki/Slave_Mind)  for some dialogue later.
-- ::item:: [URL](https://bg3.wiki/wiki/Lae%27zel) Recruit a companion for some missable items.
-- ::item:: [URL](https://bg3.wiki/wiki/Shadowheart) Recruit a second companion for some missable items.
-- ::item:: [URL](https://bg3.wiki/wiki/Bandit%27s%20Armour) Unequip a companion for a missable item later.
-- ::item:: [URL](https://bg3.wiki/wiki/Everburn_Blade) Kill or Command (Drop) an enemy for a missable item.
+- ::item_common:: Pick up some missable items [1](https://bg3.wiki/wiki/Dark_Mind) [2](https://bg3.wiki/wiki/Slave_Mind)  for some dialogue later.
+- ::item_common:: [URL](https://bg3.wiki/wiki/Lae%27zel) Recruit a companion for some missable items.
+- ::item_common:: [URL](https://bg3.wiki/wiki/Shadowheart) Recruit a second companion for some missable items.
+- ::item_common:: [URL](https://bg3.wiki/wiki/Bandit%27s%20Armour) Unequip a companion for a missable item later.
+- ::item_uncommon:: [URL](https://bg3.wiki/wiki/Everburn_Blade) Kill or Command (Drop) an enemy for a missable item.
 # Ravaged Beach
 - Take revenge on your tentacled captor from the intro
 # Wilderness

--- a/checklist.md
+++ b/checklist.md
@@ -25,7 +25,7 @@
 - Complete other quests before [killing 3 goblin camp leaders](https://bg3.wiki/wiki/Defeat_the_Goblins)
 # Nautiloid
 - ::ability:: Make a [friend](https://bg3.wiki/wiki/Us) and keep him alive to be granted a missable ability later.
-- ::item_common:: Pick up some missable items [1](https://bg3.wiki/wiki/Dark_Mind) [2](https://bg3.wiki/wiki/Slave_Mind)  for some dialogue later.
+- ::item_ordinary:: Pick up some missable items [1](https://bg3.wiki/wiki/Dark_Mind) [2](https://bg3.wiki/wiki/Slave_Mind)  for some dialogue later.
 - ::item_ordinary:: Recruit a [companion](https://bg3.wiki/wiki/Lae%27zel) for some missable items.
 - ::item_ordinary:: Recruit a second [companion](https://bg3.wiki/wiki/Shadowheart) for some missable items.
 - ::item_ordinary:: Unequip a companion for a missable [item](https://bg3.wiki/wiki/Bandit%27s%20Armour) later.

--- a/checklist.md
+++ b/checklist.md
@@ -24,12 +24,15 @@
 - If you reach a [burning building](https://bg3.wiki/wiki/Waukeen's_Rest), do not long rest
 - Complete other quests before [killing 3 goblin camp leaders](https://bg3.wiki/wiki/Defeat_the_Goblins)
 # Nautiloid
-- ::ability:: Make a [friend](https://bg3.wiki/wiki/Us) and keep him alive to be granted a missable ability later.
-- ::item_ordinary:: Pick up some missable items [1](https://bg3.wiki/wiki/Dark_Mind) [2](https://bg3.wiki/wiki/Slave_Mind)  for some dialogue later.
-- ::item_ordinary:: Recruit a [companion](https://bg3.wiki/wiki/Lae%27zel) for some missable items [1](https://bg3.wiki/wiki/Githyanki_Boots) [2](https://bg3.wiki/wiki/Lae%27zel%27s_Clothes) [3](https://bg3.wiki/wiki/Lae%27zel%27s_Underwear) [4](https://bg3.wiki/wiki/Tasteful_Boots).
-- ::item_ordinary:: Recruit a second [companion](https://bg3.wiki/wiki/Shadowheart) for some missable items [1](https://bg3.wiki/wiki/Circlet) [2](https://bg3.wiki/wiki/Chain_Shirt) [3](https://bg3.wiki/wiki/Shadowheart%27s_Clothes) [4](https://bg3.wiki/wiki/Shadowheart%27s_Underwear) [5](https://bg3.wiki/wiki/Tasteful_Boots).
-- ::item_ordinary:: Unequip a companion for a missable [item](https://bg3.wiki/wiki/Bandit%27s%20Armour) later.
-- ::item_uncommon:: Kill or Command (Drop) an [enemy](https://bg3.wiki/wiki/Zhalk) for a missable [item](https://bg3.wiki/wiki/Everburn_Blade).
+- ::ability:: Missable or limited skills, spells or abilities:
+  - ::ability:: Make a [friend](https://bg3.wiki/wiki/Us) and keep him alive to be granted a missable ability later.
+- ::item_ordinary:: Missable or limited ordinary items.  Ordinary items may be unique in name, but don't differ from regular items.
+  - ::item_ordinary:: Pick up some missable items [1](https://bg3.wiki/wiki/Dark_Mind) [2](https://bg3.wiki/wiki/Slave_Mind)  for some dialogue later.
+  - ::item_ordinary:: Recruit a [companion](https://bg3.wiki/wiki/Lae%27zel) for some missable items [1](https://bg3.wiki/wiki/Githyanki_Boots) [2](https://bg3.wiki/wiki/Lae%27zel%27s_Clothes) [3](https://bg3.wiki/wiki/Lae%27zel%27s_Underwear) [4](https://bg3.wiki/wiki/Tasteful_Boots).
+  - ::item_ordinary:: Recruit a second [companion](https://bg3.wiki/wiki/Shadowheart) for some missable items [1](https://bg3.wiki/wiki/Circlet) [2](https://bg3.wiki/wiki/Chain_Shirt) [3](https://bg3.wiki/wiki/Shadowheart%27s_Clothes) [4](https://bg3.wiki/wiki/Shadowheart%27s_Underwear) [5](https://bg3.wiki/wiki/Tasteful_Boots).
+  - ::item_ordinary:: Unequip a companion for a missable [item](https://bg3.wiki/wiki/Bandit%27s%20Armour) later.
+- ::item_common:: Missable or limited items.
+  - ::item_uncommon:: Kill or Command (Drop) an [enemy](https://bg3.wiki/wiki/Zhalk) for a missable [item](https://bg3.wiki/wiki/Everburn_Blade).
 # Ravaged Beach
 - Take revenge on your tentacled captor from the intro
 # Wilderness

--- a/checklist.md
+++ b/checklist.md
@@ -228,15 +228,15 @@
 # House in Deep Shadows
 - Play hide and seek with [a child](https://bg3.wiki/wiki/Oliver), get [a cool ring](https://bg3.wiki/wiki/Ring_of_Shadows)
 # Ruined Battlefield
-- ::item_story:: First opportunity to find a [Moonlantern](https://bg3.wiki/wiki/Moonlantern), dropped from an [enemy](https://bg3.wiki/wiki/Kar%27niss).
-  - ::missable:: This version of the item is time limited and must be obtained before the target reaches Moonrise Towers (depending on how the player entered Act 2).  It is recommended to obtain this item ASAP.
-  - ::item_common:: It is higly recommended to get this one, as it grants another missable [item](https://bg3.wiki/wiki/Filigreed_Feywild_Bell) and affects a future interaction with a little [friend](https://bg3.wiki/wiki/Dolly_Dolly_Dolly)
+- ::item_story:: First opportunity to find a [Moonlantern](https://bg3.wiki/wiki/Moonlantern), dropped from [Kar'niss](https://bg3.wiki/wiki/Kar%27niss).
+  - ::missable:: This version of the item is time limited and, depending on how the player entered Act 2, must be obtained before the target reaches Moonrise Towers.  It is recommended to obtain this item ASAP.
+  - ::item_common:: It is higly recommended to get this one as it grants another item, the [Filigreed Feywild Bell](https://bg3.wiki/wiki/Filigreed_Feywild_Bell), and affects a future interaction with [Dolly Dolly Dolly](https://bg3.wiki/wiki/Dolly_Dolly_Dolly)
 - Talk to a man who wants to [make things "right" by interrogating a dead barkeeper](https://bg3.wiki/wiki/Punish_the_Wicked)
 - Save some harpers, find out about the Inn
 - Give a certain companion [a certain flower](https://bg3.wiki/wiki/Night_Orchid) they might have mentioned
 - Destroy the everburning torches next to Korliss and fight the shadow mastiffs
 # Last Light Inn
-- ::item_story:: Second chance to get a missable [item](https://bg3.wiki/wiki/Moonlantern).
+- ::item_story:: Second chance to get a [Moonlantern](https://bg3.wiki/wiki/Moonlantern).
 - Talk to the inhabitants of [the Inn](https://bg3.wiki/wiki/Last_Light_Inn)
   - Make sure to speak with a pair playing chess ([a tiefling child](https://bg3.wiki/wiki/Mol) and [a familiar opponent](https://bg3.wiki/wiki/Raphael))
   - Talk to [a Strange Ox](https://bg3.wiki/wiki/Strange_Ox) again (don't kill it)
@@ -250,7 +250,7 @@
   - Visit camp to find out more about [the boy](https://bg3.wiki/wiki/Thaniel), post-attack
 - Give [Dammon](https://bg3.wiki/wiki/Dammon) what [he needs](https://bg3.wiki/wiki/Infernal_Iron) to help [Karlach](https://bg3.wiki/wiki/Karlach), two times
 # Moonrise Towers
-- ::item_story:: Final chance to get a missable [item](https://bg3.wiki/wiki/Moonlantern).
+- ::item_story:: Final chance to get a [Moonlantern](https://bg3.wiki/wiki/Moonlantern).
 - Get some more tadpoles
   - Convince the guard on the docks to let you investigate the shipping crates
   - Destroy the barrel with the tadpoles after investigating (you can move the crate out of sight of the guards)

--- a/checklist.md
+++ b/checklist.md
@@ -75,7 +75,7 @@
 - Rescue [Halsin](https://bg3.wiki/wiki/Halsin) 
 - Eliminate the [three True Soul goblin leaders](https://bg3.wiki/wiki/Defeat_the_Goblins)
 # Shattered Sanctum
-- ::story_item:: The first opportunity to obtain a [Spider Lyre](https://bg3.wiki/wiki/Spider%27s%20Lyre).
+- ::item_story:: The first opportunity to obtain a [Spider Lyre](https://bg3.wiki/wiki/Spider%27s%20Lyre).
 # The Risen Road
 - Meet [Karlach](https://bg3.wiki/wiki/Karlach)
 - ::missable::[Deal with the paladins](https://bg3.wiki/wiki/Hunt_the_Devil) she brings up before going to Act 1.5, or deal with some permanent consequences

--- a/checklist.md
+++ b/checklist.md
@@ -4,7 +4,10 @@
 - This guide assumes you're completing everything on your quest log -- this list contains mostly tasks you may miss without seeing a related Journal entry
 - Always crouch when stealing -- enemies will automatically  start investigating if not
 - Send all camp supplies to camp -- they'll automatically show up when you Long Rest
-- ::task::This represents general tasks. ::item::This represents missable or limited items. ::ability::This represents missable or limited skills, spells or abilities. ::missable::This represents time sensitive mechanics that can be failed.
+- ::task::This represents general tasks.
+- ::item::This represents missable or limited items.
+- ::ability::This represents missable or limited skills, spells or abilities.
+- ::missable::This represents time sensitive mechanics that can be failed.
 # Act 1 Main Missables Entry List
 - Turn in a quest to [save the tieflings](https://bg3.wiki/wiki/Save_the_Refugees) in the grove -- you'll get a pair of gloves 
 - ::missable::Buy any [goblin vendor](https://bg3.wiki/wiki/Grat_the_Trader) items before angering the goblin camp

--- a/checklist.md
+++ b/checklist.md
@@ -13,6 +13,7 @@
 - If you reach a [burning building](https://bg3.wiki/wiki/Waukeen's_Rest), do not long rest
 - Complete other quests before [killing 3 goblin camp leaders](https://bg3.wiki/wiki/Defeat_the_Goblins)
 # Nautiloid
+- ::gem:: test
 - Kill [the devil](https://bg3.wiki/wiki/Commander_Zhalk) to get the [fiery sword](https://bg3.wiki/wiki/Everburn_Blade) (it's useful at least partway through Act 1)
 - Make a decision about the exposed brain -- sparing it may be relevant later in Act 2
 - Grab some green jars ([1](https://bg3.wiki/wiki/Dark_Mind), [2](https://bg3.wiki/wiki/Slave_Mind)) and hold them until the end of Act 2 for interesting dialogue later, although nothing is lost if you don't get them

--- a/checklist.md
+++ b/checklist.md
@@ -39,8 +39,6 @@
 - [Help Lae'zel](https://bg3.wiki/wiki/Lae%27zel#Recruitment) drop out of her wooden bars
 # Roadside Cliffs (Harper's Outpost)
 - Optionally (very optionally) get [five temporary spider friends](https://bg3.wiki/wiki/Spider_Egg_Sac)
-# Overgrown Ruins
-# Refectory
 # Dank Crypt
 - Gain access to [a character that re-specs you](https://bg3.wiki/wiki/Withers)
 - Check out the [secret book](https://bg3.wiki/wiki/Book_of_Dead_Gods) that reveals information about gods
@@ -65,20 +63,10 @@
 - After [recruiting a new bear friend](https://bg3.wiki/wiki/Rescue_the_Druid_Halsin), speak to Rath and enter the [Druid vault](https://bg3.wiki/wiki/Hidden_Vault)
 - Optionally [steal the Idol for Mol](https://bg3.wiki/wiki/Steal_the_Sacred_Idol) (BEFORE finishing Goblin Camp, and after exposing Kagha)
 - After rescuing the Tieflings, get the Hellrider's Pride from [Zevlor](https://bg3.wiki/wiki/Zevlor)
-# Druid's Chambers
-# Enclave Library
-# Hidden Vault
-# Inner Sanctum
-# Sacred Pool
-# Secluded Chamber
 # Secluded Cove
 - ::item_story:: Perform with [Alfira](https://bg3.wiki/wiki/Alfira) to obtain an [Lute](https://bg3.wiki/wiki/Lihala%27s%20Lute).
-# Servants' Quarters
 # The Hollow
 - ::item_story:: Find the [stolen locket](https://bg3.wiki/wiki/Brass%20Locket) to complete a [quest](https://bg3.wiki/wiki/Return_the_Locket).
-# Tiefling Hideout
-# Forest
-# Underground Passage
 # Goblin Camp
 - [Chase the chicken](https://bg3.wiki/wiki/Owlbear_Cub) (do the Owlbear Cave first)
 - Rescue [Volo](https://bg3.wiki/wiki/Volo)
@@ -88,14 +76,11 @@
 - Eliminate the [three True Soul goblin leaders](https://bg3.wiki/wiki/Defeat_the_Goblins)
 # Shattered Sanctum
 - ::story_item:: The first opportunity to obtain a [Spider Lyre](https://bg3.wiki/wiki/Spider%27s%20Lyre).
-# Worg Pens
-# Defiled Temple
 # The Risen Road
 - Meet [Karlach](https://bg3.wiki/wiki/Karlach)
 - ::missable::[Deal with the paladins](https://bg3.wiki/wiki/Hunt_the_Devil) she brings up before going to Act 1.5, or deal with some permanent consequences
 - Find the [Silver Pendant](https://bg3.wiki/wiki/Silver_Pendant) 
 - ::missable::Protect [two](https://bg3.wiki/wiki/Rugan) [people](https://bg3.wiki/wiki/Olly) being attacked by furries to start the [missing shipment](https://bg3.wiki/wiki/Find_the_Missing_Shipment) quest (if you encounter them and long rest without saving them, they'll permanently die)
-# The Risen Road (Toll House)
 # Blighted Village
 - ::item_story:: The first opportunity to find the [Bloody Amulet](https://bg3.wiki/wiki/Bloody%20Amulet).  It is not recommended to obtain this.
 - ::missable::Find two new friends [next to a dead man](https://bg3.wiki/wiki/Edowin) (if you don't interact in time they'll leave)
@@ -112,8 +97,6 @@
 - Kill the [ogres](https://bg3.wiki/wiki/Lump_the_Enlightened)
   - Nab the [Headband of Intellect](https://bg3.wiki/wiki/Warped_Headband_of_Intellect)
 - In one of the houses north of the village, there is a bugbear having a moment with their partner
-# Apothecary's Cellar
-# Whispering Depths
 # Mountain Pass
 - After you discover [Kith'rak Voss](https://bg3.wiki/wiki/Kith%27rak_Voss), speak to him before long resting, or deal with some permanent consequences
 - If you decide to fight, remember you can cause [Kith'rak Voss](https://bg3.wiki/wiki/Kith%27rak_Voss) to drop his sword for Lae'zel with the command spell
@@ -139,9 +122,6 @@
 # Riverside Teahouse
 - Save a [pregnant mother](https://bg3.wiki/wiki/Save_Mayrina)
 - ::item_story:: A missable [item](https://bg3.wiki/wiki/Mayrina%27s%20Locket) can be obtained here.  Obtaining this item may prevent obtaining other items, so it is not recommended to collect this one. (Alternate methods may be available. Verification needed.)
-# Overgrown Tunnel
-# Overgrown Tunnel (Ancient Abode)
-# Overgrown Tunnel (Acrid Workshop)
 # Underdark
 - Clear out the [outpost area that offers protection from monsters](https://bg3.wiki/wiki/Sel%C3%BBnite_Outpost)
   - Light the sconces and braziers in the area to solve the wall puzzles 
@@ -163,12 +143,6 @@
 - Fight [a land shark](https://baldursgate3.wiki.fextralife.com/Bulette)
 - If you find a small grave site in a clearing, don't touch it until you read a certain note regarding a canine companion in the Arcane Tower
   - Once you've done that, grab the collar from within and use it with the Arcane Tower button
-# Bibberbang Grotto
-# Decrepit Village
-# Dread Hollow
-# Myconid Colony
-# Selûnite Outpost
-# The Festering Cove
 # Arcane Tower
 - Use the dog collar to [achieve an unexpected result with a button](https://bg3.wiki/wiki/Dog_Collar)
   - Find and dig on a dog's grave on the Underdark Road to find the necessary item
@@ -190,9 +164,6 @@
 - Loot the [mimics](https://bg3.wiki/wiki/Mimic)
 - Kill some [piggies](https://bg3.wiki/wiki/Hellsboar) in [the area](https://bg3.wiki/wiki/Grymforge#Abandoned_Temple) and optionally get [some masks](https://bg3.wiki/wiki/Devilfoil_Mask)
 - Don't take the elevator up until you've done the creche and other Act 1.5 content
-# Abandoned Refuge
-# Abandoned Refuge (Ancient Forge)
-# The Adamantine Forge
 # BEFORE CONTINUING TO ACT 1.5
 - Clear anything remaining in your quest log for the area (some items will be unresolved, but do whatever's on your map) before going to Act 1.5
 # Rosymorn Monastery Trail
@@ -212,10 +183,6 @@
 - Have a conversation with [the inquisitor](https://bg3.wiki/wiki/W%27wargaz)
 - Perform an [Astral Plane](https://bg3.wiki/wiki/Astral_Plane) visit, and then talk to Lae'zel
   - Talk to [the visitor](https://bg3.wiki/wiki/Voss) upon a long rest
-# Crèche Y'llek (Classroom)
-# Crèche Y'llek (Hatchery)
-# Crèche Y'llek (Infirmary)
-# Crèche Y'llek (Inquisitor's Chamber)
 # BEFORE CONTINUING TO ACT 2
 - Let a certain Dandy [shove an icepick in your eye](https://bg3.wiki/wiki/Volo%27s_Ersatz_Eye) for a permanent upgrade (unconfirmed that this has to be before Act 2)
 - Deluxe edition -- portraits: optionally find Fane in The Ruins, Lohse near Nettie in The Emerald Grove, Red Prince in the Waukeen's Rest, Ifan in the Blighted Village, Sebille in the Hag's house, and finally Beast in The Arcane Tower 
@@ -266,7 +233,6 @@
 - [Save the gnomes](https://bg3.wiki/wiki/Rescue_Wulbren) (talk to them before freeing them)
 - [Save the tieflings](https://bg3.wiki/wiki/Rescue_the_Tieflings) 
   - Talk to [the aspiring Tiefling wizard](https://bg3.wiki/wiki/Rolan)
-# Moonrise Towers (Ketheric's Room)
 # Oubliette
 - Enter [the area under the prisons](https://bg3.wiki/wiki/Oubliette)
 - Get the parasite from a Zealot corpse in the main area you drop into
@@ -281,7 +247,6 @@
   - Use a [Tower-Shaped Key](https://bg3.wiki/wiki/Tower-Shaped_Key)
 - Investigate [a particular resistance group](https://bg3.wiki/wiki/Investigate_the_Sel%C3%BBnite_Resistance)
 - Check [the cave](https://bg3.wiki/wiki/Mason's_Guild#Mason's_Guild_Basement) under the masonary
-# Reithwin Graveyard
 # House of Healing
 - Find [the lost tiefling child's parents](https://bg3.wiki/wiki/Find_Arabella%27s_Parents)
 - Kill [a surgeon with questionable ethics](https://bg3.wiki/wiki/Malus_Thorm) and take his instrument 
@@ -298,7 +263,6 @@
   - Keep her from doing anything to you for [an achievement](https://bg3.wiki/wiki/Achievements)
 # BEFORE CONTINUING TO THE TEMPLE
 - Clear anything remaining in your quest log for the area (some items will be unresolved, but do whatever's on your map) before entering the Temple
-# Grand Mausoleum
 # Gauntlet of Shar
 - Check out the path to the right of the entryway statue for treasure "hidden in darkness"
 - Kill [Balthazar](https://bg3.wiki/wiki/Balthazar)
@@ -311,8 +275,6 @@
   - [Soft-Step Trial](https://bg3.wiki/wiki/Gauntlet_of_Shar#Soft-Step_Trial)
   - [Self-Same Trial](https://bg3.wiki/wiki/Gauntlet_of_Shar#Self-Same_Trial)
   - [Faith-Leap Trial](https://bg3.wiki/wiki/Gauntlet_of_Shar#Faith-Step_Trial)
-# Silent Library
-# Shadowfell
 # Moonrise Towers (Revisited)
 - Visit [the Inn](https://bg3.wiki/wiki/Last_Light_Inn) and gather forces
   - Talk to [the Selunite](https://bg3.wiki/wiki/Isobel)
@@ -345,88 +307,10 @@
 - ::missable::[Stop the bad news](https://bg3.wiki/wiki/Stop_the_Presses) from spreading before making a long rest
 - When meeting a Djinni at a circus, trick your way into winning the jackpot!
   - ::missable:: When he teleports you to another area, loot everything since you can't go back to [that place](https://bg3.wiki/wiki/Jungle)
-# Abandoned Windmill
-# Ancient Lair
-# Angleiron's Cellar
-# Arfur's Mansion
-# Arfur's Mansion (Basement)
-# Astral Plane
-# Baldur's Mouth
-# Baldur's Mouth (Basement)
-# Basilisk Gate Barracks
-# Bloomridge Park
-# Bonecloak's Apothecary
-# Campsite
-# Carm's Garm
-# Cazador's Dungeon
-# Chromatic Scale
-# Circus of the Last Days
-# Cloister of Sombre Embrace
-# Crimson Draughts
-# Danthelon's Dancing Axe
-# Devil's Den
-# Devil's Fee
-# Elerrathin's Home
-# Elerrathin's Home (Jaheira's Basement)
-# Elfsong Tavern
-# Elfsong Tavern (Basement)
-# Elminster's Library
-# Facemaker's Boutique
-# Felogyr's Fireworks
-# Flymm Cargo
-# Flymm's Cobblers
-# Forge of the Nine
-# Fraygo's Flophouse
-# Guildhall
-# Gur Camp
-# Heapside Prison
-# Hhune Mausoleum
-# Highberry's Home
-# House of Grief
-# House of Hope
-# Iron Throne
-# Jungle
-# Knights of the Shield Hideout
-# Lady Jannath's Estate
 # Lower City
 - ::item_story:: [URL](https://bg3.wiki/wiki/Guild%20Ring)
-# Lower City Sewers
-# Morphic Pool
 # Murder Tribunal
 - ::item_story:: [URL](https://bg3.wiki/wiki/Amulet%20of%20Bhaal)
-# Nortale's Hostel
-# Old Garlow's Place
-# Open Hand Temple
-# Philgrave's Mansion
-# Ramazith's Tower
-# Requisitioned Barn
-# Rivington
-# Rivington (Western Beach)
-# Sharess' Caress
-# Sharran Enclave
-# Sorcerous Sundries
-# Steel Watch Foundry
-# Stormshore Armoury
-# Stormshore Tabernacle
-# Sword Coast Couriers
 # Szarr Palace
 - ::item_story:: [URL](https://bg3.wiki/wiki/Szarr%20Family%20Ring)
-# Temple of Bhaal
-# The Bibliophile
-# The Blushing Mermaid
-# The Counting House
-# The Dragon's Sanctum
-# The Glitter Gala
-# The High Hall
-# The Lodge
-# The Lodge - Basement Docks
-# The Wyrmway
-# Under Temple Cave Area
-# Undercity Ruins
-# Vonayn's Home
-# Water Queen's House
-# Windmill Basement
-# Wine Festival
-# Wyrm's Crossing
-# Wyrm's Crossing (The Velveteen Elixir)
 # Wyrm's Rock Fortress

--- a/checklist.md
+++ b/checklist.md
@@ -26,10 +26,10 @@
 # Nautiloid
 - ::ability:: Make a [friend](https://bg3.wiki/wiki/Us) that can grant a missable ability later.
 - ::item_common:: Pick up some missable items [1](https://bg3.wiki/wiki/Dark_Mind) [2](https://bg3.wiki/wiki/Slave_Mind)  for some dialogue later.
-- ::item_common:: [URL](https://bg3.wiki/wiki/Lae%27zel) Recruit a companion for some missable items.
-- ::item_common:: [URL](https://bg3.wiki/wiki/Shadowheart) Recruit a second companion for some missable items.
-- ::item_common:: [URL](https://bg3.wiki/wiki/Bandit%27s%20Armour) Unequip a companion for a missable item later.
-- ::item_uncommon:: [URL](https://bg3.wiki/wiki/Everburn_Blade) Kill or Command (Drop) an enemy for a missable item.
+- ::item_common:: Recruit a [companion](https://bg3.wiki/wiki/Lae%27zel) for some missable items.
+- ::item_common:: Recruit a second [companion](https://bg3.wiki/wiki/Shadowheart) for some missable items.
+- ::item_common:: Unequip a companion for a missable [item](https://bg3.wiki/wiki/Bandit%27s%20Armour) later.
+- ::item_uncommon:: Kill or Command (Drop) an [enemy](https://bg3.wiki/wiki/Zhalk) for a missable [item](https://bg3.wiki/wiki/Everburn_Blade).
 # Ravaged Beach
 - Take revenge on your tentacled captor from the intro
 # Wilderness

--- a/js/main.js
+++ b/js/main.js
@@ -64,6 +64,34 @@ function generateTasks() {
             '<i class="bi bi-gem"></i>'
           );
           listItemText = listItemText.replace(
+            /::item_ordinary::/g,
+            '<i class="bi bi-gem"></i>'
+          );
+                    listItemText = listItemText.replace(
+            /::item_common::/g,
+            '<i class="bi bi-gem"></i>'
+          );
+                    listItemText = listItemText.replace(
+            /::item_uncommon::/g,
+            '<i class="bi bi-gem text-success"></i>'
+          );
+                    listItemText = listItemText.replace(
+            /::item_rare::/g,
+            '<i class="bi bi-gem text-primary"></i>'
+          );
+                    listItemText = listItemText.replace(
+            /::item_veryrare::/g,
+            '<i class="bi bi-gem text-danger"></i>'
+          );
+                    listItemText = listItemText.replace(
+            /::item_legendary::/g,
+            '<i class="bi bi-gem text-warning"></i>'
+          );
+                    listItemText = listItemText.replace(
+            /::item_story::/g,
+            '<i class="bi bi-gem"></i>'
+          );
+          listItemText = listItemText.replace(
             /::ability::/g,
             '<i class="bi bi-mortarboard"></i>'
           );

--- a/js/main.js
+++ b/js/main.js
@@ -56,49 +56,49 @@ function generateTasks() {
 
           // Replace ::missable:: with a clock icon, ::item:: with the gem icon, ::ability:: with mortarboard icon, and ::task::, if present or added above
           listItemText = listItemText.replace(
-            /::missable::/g,
+            /::missable::\s*/g,
             '<i class="bi bi-stopwatch text-danger"></i>'
           );
           listItemText = listItemText.replace(
-            /::item::/g,
+            /::item::\s*/g,
             '<i class="bi bi-gem"></i>'
           );
           listItemText = listItemText.replace(
-            /::item_ordinary::/g,
+            /::item_ordinary::\s*/g,
             '<i class="bi bi-patch-minus"></i>'
           );
           listItemText = listItemText.replace(
-            /::item_common::/g,
+            /::item_common::\s*/g,
             '<i class="bi bi-gem"></i>'
           );
           listItemText = listItemText.replace(
-            /::item_uncommon::/g,
+            /::item_uncommon::\s*/g,
             '<i class="bi bi-gem text-success"></i>'
           );
           listItemText = listItemText.replace(
-            /::item_rare::/g,
+            /::item_rare::\s*/g,
             '<i class="bi bi-gem text-primary"></i>'
           );
           listItemText = listItemText.replace(
-            /::item_veryrare::/g,
+            /::item_veryrare::\s*/g,
             '<i class="bi bi-gem text-danger"></i>'
           );
           listItemText = listItemText.replace(
-            /::item_legendary::/g,
+            /::item_legendary::\s*/g,
             '<i class="bi bi-gem text-warning"></i>'
           );
           listItemText = listItemText.replace(
-            /::item_story::/g,
+            /::item_story::\s*/g,
             '<i class="bi bi-book text-danger"></i>'
           );
           listItemText = listItemText.replace(
-            /::ability::/g,
+            /::ability::\s*/g,
             '<i class="bi bi-mortarboard"></i>'
           );
           listItemText = listItemText.replace(
-            /::task::/g,
+            /::task::\s*/g,
             '<i class="bi bi-clipboard-check"></i>'
-          );
+          );          
 
           // Convert markdown-style links to HTML links
           const linkPattern = /\[(.*?)\]\((.*?)\)/g;

--- a/js/main.js
+++ b/js/main.js
@@ -57,7 +57,7 @@ function generateTasks() {
           // Replace ::missable:: with a clock icon, ::item:: with the gem icon, ::ability:: with mortarboard icon, and ::task::, if present or added above
           listItemText = listItemText.replace(
             /::missable::/g,
-            '<i class="bi bi-stopwatch"></i>'
+            '<i class="bi bi-stopwatch text-warning"></i>'
           );
           listItemText = listItemText.replace(
             /::item::/g,

--- a/js/main.js
+++ b/js/main.js
@@ -57,7 +57,7 @@ function generateTasks() {
           // Replace ::missable:: with a clock icon, ::item:: with the gem icon, ::ability:: with mortarboard icon, and ::task::, if present or added above
           listItemText = listItemText.replace(
             /::missable::/g,
-            '<i class="bi bi-stopwatch text-warning"></i>'
+            '<i class="bi bi-stopwatch text-danger"></i>'
           );
           listItemText = listItemText.replace(
             /::item::/g,

--- a/js/main.js
+++ b/js/main.js
@@ -54,18 +54,22 @@ function generateTasks() {
             listItemText = "::task::" + listItemText;
           } 
 
-          // Replace ::gem:: with the gem icon and ::missable:: with a clock icon, and ::task::, if present or added above
+          // Replace ::missable:: with a clock icon, ::item:: with the gem icon, ::ability:: with mortarboard icon, and ::task::, if present or added above
           listItemText = listItemText.replace(
-            /::task::/g,
-            '<i class="bi bi-clipboard-check"></i>'
+            /::missable::/g,
+            '<i class="bi bi-stopwatch"></i>'
           );
           listItemText = listItemText.replace(
             /::item::/g,
             '<i class="bi bi-gem"></i>'
           );
           listItemText = listItemText.replace(
-            /::missable::/g,
-            '<i class="bi bi-stopwatch-fill"></i>'
+            /::ability::/g,
+            '<i class="bi bi-mortarboard"></i>'
+          );
+          listItemText = listItemText.replace(
+            /::task::/g,
+            '<i class="bi bi-clipboard-check"></i>'
           );
 
           // Convert markdown-style links to HTML links

--- a/js/main.js
+++ b/js/main.js
@@ -65,31 +65,31 @@ function generateTasks() {
           );
           listItemText = listItemText.replace(
             /::item_ordinary::/g,
-            '<i class="bi bi-gem"></i>'
+            '<i class="bi bi-patch-minus"></i>'
           );
-                    listItemText = listItemText.replace(
+          listItemText = listItemText.replace(
             /::item_common::/g,
             '<i class="bi bi-gem"></i>'
           );
-                    listItemText = listItemText.replace(
+          listItemText = listItemText.replace(
             /::item_uncommon::/g,
             '<i class="bi bi-gem text-success"></i>'
           );
-                    listItemText = listItemText.replace(
+          listItemText = listItemText.replace(
             /::item_rare::/g,
             '<i class="bi bi-gem text-primary"></i>'
           );
-                    listItemText = listItemText.replace(
+          listItemText = listItemText.replace(
             /::item_veryrare::/g,
             '<i class="bi bi-gem text-danger"></i>'
           );
-                    listItemText = listItemText.replace(
+          listItemText = listItemText.replace(
             /::item_legendary::/g,
             '<i class="bi bi-gem text-warning"></i>'
           );
-                    listItemText = listItemText.replace(
+          listItemText = listItemText.replace(
             /::item_story::/g,
-            '<i class="bi bi-gem"></i>'
+            '<i class="bi bi-book text-danger"></i>'
           );
           listItemText = listItemText.replace(
             /::ability::/g,


### PR DESCRIPTION
Added new icons using the tags "item_common", "item_uncommon", "item_rare", "item_veryrare", "item_legendary", "item_story", "item_ordinary" and "ability".  These icons use different colors.

Added a key to explain items under the first heading.

Changed the color of the "missable" icon.

Changed the Nautiloid section to reflect usage of new icons.

All story based <ins>**equipment**</ins> has been added (there was not that many).  Minor edits to sections that touched on already existing story equipment was done.

Location names for all areas have been changed to reflect the wiki, which should be the actual names in-game.  I don't personally believe area names are bad enough to be spoilers, but some might think so.  I am working on importing items into the walkthrough and the need for the area names to be accurate for the moment is important.  After it is done, the names can be changed to something more obscure.

Not included: I've prepared a separate branch that includes the location for every area in the game.  At this time I've removed the empty headers, but future PR's may include them (this is why I'd like location names to stay as they are for now).

If there is no issues with this PR, I can attempt a much larger import of the item list.