### PR TITLE
Update deprecated GitHub Actions to v4

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -30,9 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v2
         with:


### PR DESCRIPTION
Update actions/checkout from v3 to v4
Update actions/configure-pages from v3 to v4
Resolves deprecation warnings in GitHub Pages workflow